### PR TITLE
doc: nice!view display confirmed working

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a split, wireless-only mechanical keyboard fashioned after the [chocofi 
 - Kailh choc hotswap sockets
 - Intended to be used with [nice!nano](https://nicekeyboards.com/nice-nano)
 - Uses 7-pin SPDT power switch and includes pads for battery on keyboard shield PCB
-- Support for [nice!view](https://nicekeyboards.com/nice-view), though this hasn't been tested yet
+- Support for [nice!view](https://nicekeyboards.com/nice-view)
 - Compatible with chocofi cases and plates
 
 ![temper keyboard](images/temper.jpg)


### PR DESCRIPTION
Thanks again for this board! I finally got around to finishing my build over the holiday break (my first custom build, actually), and can confirm that the nice!view displays work perfectly.

For those interested in adding this as well, after installing the screens just update the `build.yaml` to include the nice!view adaptor and shield, e.g.:

```yaml
include:
  - board: nice_nano_v2
    shield: temper_left nice_view_adapter nice_view
```

I can include a photo if you'd like to add it?